### PR TITLE
Relax types to abstract arrays

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ export convn, fastconv
 # Alexander Amini, Alan Edelman, Berthold Horn
 ##############################################
 
-@generated function convn(E::Array{T,N}, k::Array{T,N}) where {T,N}
+@generated function convn(E::AbstractArray{T,N}, k::AbstractArray{T,N}) where {T,N}
     quote
         sizeThreshold = 21;
         if length(k) <= sizeThreshold || $N > 2
@@ -28,7 +28,7 @@ export convn, fastconv
 end
 
 # direct version (do not check if threshold is satisfied)
-@generated function fastconv(E::Array{T,N}, k::Array{T,N}) where {T,N}
+@generated function fastconv(E::AbstractArray{T,N}, k::AbstractArray{T,N}) where {T,N}
     quote
 
         retsize = [size(E)...] + [size(k)...] .- 1
@@ -43,7 +43,7 @@ end
 
 
 # in place helper operation to speedup memory allocations
-@generated function convn!(out::Array{T}, E::Array{T,N}, k::Array{T,N}) where {T,N}
+@generated function convn!(out::AbstractArray{T}, E::AbstractArray{T,N}, k::AbstractArray{T,N}) where {T,N}
     quote
         @inbounds begin
             @nloops $N x E begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,3 +32,10 @@ k2 = rand(3,3)
 A1_2 = convn(convn(A,k1), k2)
 A_12 = fastconv(A, fastconv(k1, k2))
 @test A1_2 \approx A_12
+
+# Test Array Views
+u = Float32.(reshape(1:12,(3,4)))
+v = Float32.(reshape(1:6,(3,2)))
+y_loop = [convn(u[i,:],v[i,:]) for i in 1:size(u)[1]]
+y_broadcast = convn.(eachrow(u),eachrow(v))
+@test y_loop ≈ y_broadcast


### PR DESCRIPTION
This allows support for array views.
Technically also allows CuArrays, but `convn` requires scalar `getindex`.